### PR TITLE
Allow crystal ">= 0.31.1" in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ authors:
   - Brian J. Cardiff <bcardiff@manas.tech>
   - Franciscello <ftarulla@manas.tech>
 
-crystal: 0.31.1
+crystal: ">= 0.31.1"
 
 license: MIT


### PR DESCRIPTION
* Updated the shard.yml to allow Crystal v1.
* But the new version specification also retains the compatibility with the currently mentioned `0.31.1` version.